### PR TITLE
feat: extract rate limiting into pushpin-security-ratelimit module

### DIFF
--- a/pushpin-security-ratelimit/build.gradle.kts
+++ b/pushpin-security-ratelimit/build.gradle.kts
@@ -1,0 +1,26 @@
+plugins {
+    kotlin("jvm")
+    kotlin("plugin.spring")
+    id("org.springframework.boot") apply false
+}
+
+dependencies {
+    // Dependencies from other modules
+    api(project(":pushpin-security-core"))
+
+    // Spring Boot dependencies
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-security")
+    implementation("org.springframework.boot:spring-boot-autoconfigure")
+    implementation("jakarta.servlet:jakarta.servlet-api")
+    implementation("org.jetbrains.kotlin:kotlin-reflect")
+
+    // Rate limiting library
+    implementation("com.github.vladimir-bukhtoyarov:bucket4j-core")
+
+    // Test dependencies
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.springframework.security:spring-security-test")
+    testImplementation("org.mockito.kotlin:mockito-kotlin")
+    testImplementation(kotlin("test"))
+}

--- a/pushpin-security-ratelimit/src/main/kotlin/io/github/mpecan/pmt/security/ratelimit/RateLimitProperties.kt
+++ b/pushpin-security-ratelimit/src/main/kotlin/io/github/mpecan/pmt/security/ratelimit/RateLimitProperties.kt
@@ -1,0 +1,17 @@
+package io.github.mpecan.pmt.security.ratelimit
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+/**
+ * Configuration properties for rate limiting.
+ *
+ * @property enabled Whether rate limiting is enabled
+ * @property capacity Number of requests allowed in the time period
+ * @property refillTimeInMillis Time period for refilling tokens in milliseconds
+ */
+@ConfigurationProperties(prefix = "pushpin.security.rate-limit")
+data class RateLimitProperties(
+    val enabled: Boolean = false,
+    val capacity: Long = 100,
+    val refillTimeInMillis: Long = 60000, // 1 minute
+)

--- a/pushpin-security-ratelimit/src/main/kotlin/io/github/mpecan/pmt/security/ratelimit/config/RateLimitAutoConfiguration.kt
+++ b/pushpin-security-ratelimit/src/main/kotlin/io/github/mpecan/pmt/security/ratelimit/config/RateLimitAutoConfiguration.kt
@@ -1,0 +1,35 @@
+package io.github.mpecan.pmt.security.ratelimit.config
+
+import io.github.mpecan.pmt.security.core.AuditService
+import io.github.mpecan.pmt.security.ratelimit.RateLimitFilter
+import io.github.mpecan.pmt.security.ratelimit.RateLimitProperties
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+
+/**
+ * Auto-configuration for rate limiting functionality.
+ */
+@AutoConfiguration
+@ConditionalOnClass(RateLimitFilter::class)
+@ConditionalOnProperty(
+    prefix = "pushpin.security.rate-limit",
+    name = ["enabled"],
+    havingValue = "true",
+    matchIfMissing = false,
+)
+@EnableConfigurationProperties(RateLimitProperties::class)
+class RateLimitAutoConfiguration {
+
+    /**
+     * Creates a RateLimitFilter bean if one doesn't already exist.
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    fun rateLimitFilter(properties: RateLimitProperties, auditService: AuditService): RateLimitFilter {
+        return RateLimitFilter(properties, auditService)
+    }
+}

--- a/pushpin-security-ratelimit/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/pushpin-security-ratelimit/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+io.github.mpecan.pmt.security.ratelimit.config.RateLimitAutoConfiguration

--- a/pushpin-security-starter/build.gradle.kts
+++ b/pushpin-security-starter/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
     api(project(":pushpin-security-encryption"))
     api(project(":pushpin-security-hmac"))
     api(project(":pushpin-security-jwt"))
+    api(project(":pushpin-security-ratelimit"))
 
     // Spring Boot starter dependencies
     implementation("org.springframework.boot:spring-boot-starter")

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
     implementation(project(":pushpin-security-encryption"))
     implementation(project(":pushpin-security-hmac"))
     implementation(project(":pushpin-security-jwt"))
+    implementation(project(":pushpin-security-ratelimit"))
     implementation(project(":pushpin-transport-http"))
     implementation(project(":pushpin-transport-zmq"))
 
@@ -40,9 +41,6 @@ dependencies {
     implementation("io.jsonwebtoken:jjwt-api")
     runtimeOnly("io.jsonwebtoken:jjwt-impl")
     runtimeOnly("io.jsonwebtoken:jjwt-jackson")
-
-    // Rate limiting
-    implementation("com.github.vladimir-bukhtoyarov:bucket4j-core")
 
     // JsonPath for JWT claim extraction
     implementation("com.jayway.jsonpath:json-path")

--- a/server/src/main/kotlin/io/github/mpecan/pmt/config/RateLimitBridgeConfig.kt
+++ b/server/src/main/kotlin/io/github/mpecan/pmt/config/RateLimitBridgeConfig.kt
@@ -1,0 +1,33 @@
+package io.github.mpecan.pmt.config
+
+import io.github.mpecan.pmt.security.ratelimit.RateLimitProperties
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * Bridge configuration to adapt PushpinProperties.RateLimitProperties
+ * to the standalone RateLimitProperties for the rate limit module.
+ */
+@Configuration
+@ConditionalOnProperty(
+    prefix = "pushpin.security.rate-limit",
+    name = ["enabled"],
+    havingValue = "true",
+    matchIfMissing = false,
+)
+class RateLimitBridgeConfig {
+
+    /**
+     * Creates a RateLimitProperties bean from PushpinProperties.
+     * This allows the existing configuration to work with the new module.
+     */
+    @Bean
+    fun rateLimitProperties(pushpinProperties: PushpinProperties): RateLimitProperties {
+        return RateLimitProperties(
+            enabled = pushpinProperties.security.rateLimit.enabled,
+            capacity = pushpinProperties.security.rateLimit.capacity,
+            refillTimeInMillis = pushpinProperties.security.rateLimit.refillTimeInMillis,
+        )
+    }
+}

--- a/server/src/main/kotlin/io/github/mpecan/pmt/config/SecurityConfig.kt
+++ b/server/src/main/kotlin/io/github/mpecan/pmt/config/SecurityConfig.kt
@@ -1,9 +1,9 @@
 package io.github.mpecan.pmt.config
 
-import io.github.mpecan.pmt.security.RateLimitFilter
 import io.github.mpecan.pmt.security.core.AuditService
 import io.github.mpecan.pmt.security.core.JwtDecoderService
 import io.github.mpecan.pmt.security.hmac.HmacSignatureFilter
+import io.github.mpecan.pmt.security.ratelimit.RateLimitFilter
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
@@ -42,6 +42,9 @@ class SecurityConfig(
     @Autowired(required = false)
     private var hmacSignatureFilter: HmacSignatureFilter? = null
 
+    @Autowired(required = false)
+    private var rateLimitFilter: RateLimitFilter? = null
+
     /**
      * Configures the security filter chain.
      */
@@ -67,10 +70,10 @@ class SecurityConfig(
                     .permitAll()
             }
 
-        // Add rate limiting if enabled
-        if (pushpinProperties.security.rateLimit.enabled) {
+        // Add rate limiting if enabled and available
+        if (pushpinProperties.security.rateLimit.enabled && rateLimitFilter != null) {
             http.addFilterBefore(
-                RateLimitFilter(pushpinProperties, auditService),
+                rateLimitFilter!!,
                 UsernamePasswordAuthenticationFilter::class.java,
             )
         }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,6 +17,7 @@ include(
     ":pushpin-security-encryption",
     ":pushpin-security-hmac",
     ":pushpin-security-jwt",
+    ":pushpin-security-ratelimit",
     ":pushpin-security-starter",
     ":pushpin-transport-core",
     ":pushpin-transport-http",


### PR DESCRIPTION
## Summary
Extract rate limiting functionality into a dedicated `pushpin-security-ratelimit` module to improve modularity and follow the established pattern of security modules in the project.

## Changes
- **Created new module**: `pushpin-security-ratelimit` with proper Spring Boot autoconfiguration
- **Moved RateLimitFilter**: Extracted from server module to new dedicated module
- **Created RateLimitProperties**: Proper `@ConfigurationProperties` class with prefix `pushpin.security.rate-limit`
- **Added autoconfiguration**: Spring Boot autoconfiguration with conditional beans
- **Created bridge configuration**: `RateLimitBridgeConfig` to adapt existing `PushpinProperties` to new module
- **Updated dependencies**: 
  - Server module now depends on the new rate limit module
  - Removed bucket4j from server (now only in rate limit module)
  - Added rate limit module to security starter
- **Moved tests**: All rate limit tests moved to new module with proper package structure

## Benefits
- ✅ Improved modularity - rate limiting can be used independently
- ✅ Consistent with other security modules pattern
- ✅ Better separation of concerns
- ✅ Easier to maintain and test

## Test Plan
- [x] All existing tests pass
- [x] Rate limit module tests pass independently
- [x] Full build succeeds with `./gradlew build`
- [x] ktlint formatting checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)