### PR TITLE
feat: update CI permissions for improved access control

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+    contents: read
+    packages: write
+    id-token: write
+    actions: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to add specific permissions for the `pull_request` event in the `ci.yml` file.

Permissions update:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR9-R14): Added `contents: read`, `packages: write`, `id-token: write`, and `actions: read` permissions under the `pull_request` trigger.