### PR TITLE
fix: address critical and medium severity Dependabot alerts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ val springDependencyManagementVersion: String by project
 plugins {
     kotlin("jvm") version "1.9.25"
     kotlin("plugin.spring") version "1.9.25"
-    id("org.springframework.boot") version "3.4.4" apply false
+    id("org.springframework.boot") version "3.4.5" apply false
     id("io.spring.dependency-management") version "1.1.7"
     id("jacoco")
     id("jacoco-report-aggregation")
@@ -61,6 +61,11 @@ subprojects {
     val reactorKotlinExtensionsVersion: String by project
     val jacksonVersion: String by project
     val reactorVersion: String by project
+    val logbackVersion: String by project
+    val httpClientVersion: String by project
+    val artemisVersion: String by project
+    val tomcatVersion: String by project
+    val okioVersion: String by project
 
     // Apply dependency management
     dependencyManagement {
@@ -111,6 +116,17 @@ subprojects {
             // Monitoring dependencies
             dependency("io.micrometer:micrometer-core:$micrometerVersion")
             dependency("io.micrometer:micrometer-registry-prometheus:$micrometerVersion")
+
+            // Override vulnerable versions
+            dependency("ch.qos.logback:logback-classic:$logbackVersion")
+            dependency("ch.qos.logback:logback-core:$logbackVersion")
+            dependency("org.apache.httpcomponents.client5:httpclient5:$httpClientVersion")
+            dependency("org.apache.activemq:artemis-project:$artemisVersion")
+            dependency("org.apache.tomcat.embed:tomcat-embed-core:$tomcatVersion")
+            dependency("org.apache.tomcat.embed:tomcat-embed-el:$tomcatVersion")
+            dependency("org.apache.tomcat.embed:tomcat-embed-websocket:$tomcatVersion")
+            dependency("com.squareup.okio:okio:$okioVersion")
+            dependency("com.squareup.okio:okio-jvm:$okioVersion")
         }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ version=0.0.1-SNAPSHOT
 
 # Core versions
 kotlinVersion=1.9.25
-springBootVersion=3.4.4
+springBootVersion=3.4.5
 springDependencyManagementVersion=1.1.7
 
 # Testing versions
@@ -34,6 +34,11 @@ micrometerVersion=1.13.2
 # Utility versions
 commonsCompressVersion=1.26.0
 servletApiVersion=4.0.1
+logbackVersion=1.5.15
+httpClientVersion=5.4.3
+artemisVersion=2.41.0
+tomcatVersion=10.1.40
+okioVersion=3.4.0
 
 # Kotlin coroutines versions
 kotlinxCoroutinesVersion=1.7.3


### PR DESCRIPTION
## Summary
This PR addresses all critical, high, and medium severity Dependabot security alerts by updating vulnerable dependencies.

## Security Fixes

### High/Critical Severity
- **Spring Boot**: 3.4.4 → 3.4.5 (CVE-2025-22235) - EndpointRequest.to() creates wrong matcher
- **Apache HttpClient**: 5.4.x → 5.4.3 (CVE-2025-27820) - PSL validation logic disables domain checks
- **Apache ActiveMQ Artemis**: 2.40.0 → 2.41.0 (CVE-2025-28642) - Security vulnerability
- **Logback**: 1.3.5 → 1.5.15 (CVE-2023-6378) - Serialization vulnerability in receiver component

### Medium Severity
- **Apache Tomcat**: 10.1.33 → 10.1.40 
  - CVE-2025-31650: DoS via invalid HTTP priority header
  - CVE-2025-31651: Rewrite rule bypass
- **Okio**: < 3.4.0 → 3.4.0 (CVE-2023-3635) - DoS via malformed gzip buffer

## Changes
- Updated dependency versions in `gradle.properties`
- Added dependency overrides in `build.gradle.kts` to ensure transitive dependencies are also updated
- Fixed Spring Boot plugin version reference in build configuration

## Test Results
✅ All tests pass
✅ Build successful
✅ Ktlint checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)