### PR TITLE
Update release-please workflow to use GitHub App token

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,13 +13,15 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - name: Generate GitHub App token
+        uses: actions/create-github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.REPOSITORY_BUTLER_APP_ID }}
+          private_key: ${{ secrets.REPOSITORY_BUTLER_PEM }}
+      - uses: google-github-actions/release-please-action@v4
         id: release
         with:
+          token: ${{ steps.generate-token.outputs.token }}
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json
-          
-    outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
-      version: ${{ steps.release.outputs.version }}


### PR DESCRIPTION
Updates the release-please workflow to use GitHub App token authentication instead of the default GITHUB_TOKEN, matching the pattern used in the upsert repository.

This change requires configuring two secrets:
- REPOSITORY_BUTLER_APP_ID
- REPOSITORY_BUTLER_PEM

The GitHub App token provides enhanced permissions for release automation, allowing release-please to properly create releases and update version files across protected branches.