### PR TITLE
fix: update license references from Apache 2.0 to MIT in build configuration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,9 +48,9 @@ mavenPublishing {
         url = "https://github.com/mpecan/pushpin-missing-toolbox"
         licenses {
             license {
-                name = "Apache License 2.0"
-                url = "https://www.apache.org/licenses/LICENSE-2.0"
-                distribution = "https://www.apache.org/licenses/LICENSE-2.0"
+                name = "MIT License"
+                url = "https://opensource.org/licenses/MIT"
+                distribution = "https://opensource.org/licenses/MIT"
             }
         }
         developers {
@@ -230,9 +230,9 @@ subprojects {
                 url = "https://github.com/mpecan/pushpin-missing-toolbox"
                 licenses {
                     license {
-                        name = "Apache License 2.0"
-                        url = "https://www.apache.org/licenses/LICENSE-2.0"
-                        distribution = "https://www.apache.org/licenses/LICENSE-2.0"
+                        name = "MIT License"
+                        url = "https://opensource.org/licenses/MIT"
+                        distribution = "https://opensource.org/licenses/MIT"
                     }
                 }
                 developers {


### PR DESCRIPTION
## Summary
This PR fixes license inconsistency in the repository by updating Maven publishing configuration to correctly reference MIT License instead of Apache License 2.0.

## Changes
- Updated license references in `build.gradle.kts` from Apache License 2.0 to MIT License
- Ensures consistency with the MIT License specified in the LICENSE file
- Affects both main project and subproject publishing configurations

## Testing
- ✅ All ktlint checks pass
- ✅ Build configuration validated

🤖 Generated with [Claude Code](https://claude.ai/code)