### PR TITLE
fix: update release-please.yml to use hyphenated keys for app ID and private key

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,8 +17,8 @@ jobs:
         uses: actions/create-github-app-token@v2
         id: generate-token
         with:
-          app_id: ${{ secrets.REPOSITORY_BUTLER_APP_ID }}
-          private_key: ${{ secrets.REPOSITORY_BUTLER_PEM }}
+          app-id: ${{ secrets.REPOSITORY_BUTLER_APP_ID }}
+          private-key: ${{ secrets.REPOSITORY_BUTLER_PEM }}
       - uses: google-github-actions/release-please-action@v4
         id: release
         with:


### PR DESCRIPTION
This pull request updates the `.github/workflows/release-please.yml` file to fix a configuration issue with the `actions/create-github-app-token` action by correcting the input parameter names.

* [`.github/workflows/release-please.yml`](diffhunk://#diff-2c84033033d49186c63e6adcd705f63b11ae6814cd76c152c9c486d389fbccf3L20-R21): Changed `app_id` to `app-id` and `private_key` to `private-key` in the `actions/create-github-app-token` step to align with the expected parameter names.