### PR TITLE
feat: add Maven publish plugin for project modules and configure publishing settings

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ import com.vanniktech.maven.publish.JavadocJar
 import com.vanniktech.maven.publish.KotlinJvm
 import com.vanniktech.maven.publish.SonatypeHost
 import org.jlleitschuh.gradle.ktlint.KtlintExtension
+import org.springframework.boot.gradle.tasks.bundling.BootJar
 
 // Get versions from gradle.properties
 val kotlinVersion: String by project
@@ -83,7 +84,6 @@ subprojects {
         plugin("org.jetbrains.kotlin.plugin.spring")
         plugin("io.spring.dependency-management")
         plugin("org.jlleitschuh.gradle.ktlint")
-        plugin("com.vanniktech.maven.publish")
     }
 
     // Get all versions from gradle.properties
@@ -201,11 +201,11 @@ subprojects {
     }
 
     // Configure library modules (all except server)
-    if (project.name != "server") {
+    if (name != "server") {
         // Apply Spring Boot plugin for dependency management
         apply(plugin = "org.springframework.boot")
         // Disable bootJar and enable regular jar for libraries
-        tasks.named<org.springframework.boot.gradle.tasks.bundling.BootJar>("bootJar") {
+        tasks.named<BootJar>("bootJar") {
             enabled = false
         }
         tasks.named<Jar>("jar") {
@@ -213,40 +213,41 @@ subprojects {
         }
     }
 
-    // Configure publishing for all modules that start with "pushpin-" or are in the discovery modules
-    if (project.name.startsWith("pushpin-")) {
-        apply(plugin = "com.vanniktech.maven.publish")
-        mavenPublishing {
-            configure(
-                KotlinJvm(
-                    javadocJar = JavadocJar.Javadoc(),
-                    sourcesJar = true,
-                ),
-            )
-            coordinates("io.github.mpecan", project.name, version.toString())
+    // Configure publishing for all modules that have it enabled
+    pluginManager.withPlugin("com.vanniktech.maven.publish") {
+        configure<PublishingExtension> {
+            mavenPublishing {
+                configure(
+                    KotlinJvm(
+                        javadocJar = JavadocJar.Javadoc(),
+                        sourcesJar = true,
+                    ),
+                )
+                coordinates("io.github.mpecan", project.name, version.toString())
 
-            pom {
-                name = project.name
-                description = "Pushpin Missing Toolbox - ${project.name}"
-                url = "https://github.com/mpecan/pushpin-missing-toolbox"
-                licenses {
-                    license {
-                        name = "MIT License"
-                        url = "https://opensource.org/licenses/MIT"
-                        distribution = "https://opensource.org/licenses/MIT"
-                    }
-                }
-                developers {
-                    developer {
-                        id = "mpecan"
-                        name = "Pushpin Missing Toolbox Team"
-                        url = "https://github.com/mpecan/pushpin-missing-toolbox"
-                    }
-                }
-                scm {
+                pom {
+                    name = project.name
+                    description = "Pushpin Missing Toolbox - ${project.name}"
                     url = "https://github.com/mpecan/pushpin-missing-toolbox"
-                    connection = "scm:git:git://github.com/mpecan/pushpin-missing-toolbox.git"
-                    developerConnection = "scm:git:ssh://git@github.com/mpecan/pushpin-missing-toolbox.git"
+                    licenses {
+                        license {
+                            name = "MIT License"
+                            url = "https://opensource.org/licenses/MIT"
+                            distribution = "https://opensource.org/licenses/MIT"
+                        }
+                    }
+                    developers {
+                        developer {
+                            id = "mpecan"
+                            name = "Pushpin Missing Toolbox Team"
+                            url = "https://github.com/mpecan/pushpin-missing-toolbox"
+                        }
+                    }
+                    scm {
+                        url = "https://github.com/mpecan/pushpin-missing-toolbox"
+                        connection = "scm:git:git://github.com/mpecan/pushpin-missing-toolbox.git"
+                        developerConnection = "scm:git:ssh://git@github.com/mpecan/pushpin-missing-toolbox.git"
+                    }
                 }
             }
         }

--- a/pushpin-api/build.gradle.kts
+++ b/pushpin-api/build.gradle.kts
@@ -1,5 +1,7 @@
+plugins {
+    id("com.vanniktech.maven.publish")
+}
 // All configuration is inherited from root project
-
 dependencies {
     testImplementation(kotlin("test"))
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/pushpin-client/build.gradle.kts
+++ b/pushpin-client/build.gradle.kts
@@ -1,3 +1,6 @@
+plugins {
+    id("com.vanniktech.maven.publish")
+}
 // All configuration is inherited from root project
 
 dependencies {

--- a/pushpin-discovery-aws/build.gradle.kts
+++ b/pushpin-discovery-aws/build.gradle.kts
@@ -1,3 +1,6 @@
+plugins {
+    id("com.vanniktech.maven.publish")
+}
 // All configuration is inherited from root project
 
 dependencies {

--- a/pushpin-discovery-kubernetes/build.gradle.kts
+++ b/pushpin-discovery-kubernetes/build.gradle.kts
@@ -1,3 +1,6 @@
+plugins {
+    id("com.vanniktech.maven.publish")
+}
 // All configuration is inherited from root project
 
 dependencies {

--- a/pushpin-discovery/build.gradle.kts
+++ b/pushpin-discovery/build.gradle.kts
@@ -1,3 +1,6 @@
+plugins {
+    id("com.vanniktech.maven.publish")
+}
 // All configuration is inherited from root project
 
 dependencies {

--- a/pushpin-metrics-core/build.gradle.kts
+++ b/pushpin-metrics-core/build.gradle.kts
@@ -1,3 +1,6 @@
+plugins {
+    id("com.vanniktech.maven.publish")
+}
 // All configuration is inherited from root project
 
 dependencies {

--- a/pushpin-security-audit/build.gradle.kts
+++ b/pushpin-security-audit/build.gradle.kts
@@ -1,3 +1,6 @@
+plugins {
+    id("com.vanniktech.maven.publish")
+}
 // All configuration is inherited from root project
 
 dependencies {

--- a/pushpin-security-core/build.gradle.kts
+++ b/pushpin-security-core/build.gradle.kts
@@ -1,3 +1,6 @@
+plugins {
+    id("com.vanniktech.maven.publish")
+}
 // All configuration is inherited from root project
 
 dependencies {

--- a/pushpin-security-encryption/build.gradle.kts
+++ b/pushpin-security-encryption/build.gradle.kts
@@ -1,3 +1,6 @@
+plugins {
+    id("com.vanniktech.maven.publish")
+}
 // All configuration is inherited from root project
 
 dependencies {

--- a/pushpin-security-hmac/build.gradle.kts
+++ b/pushpin-security-hmac/build.gradle.kts
@@ -1,3 +1,6 @@
+plugins {
+    id("com.vanniktech.maven.publish")
+}
 // All configuration is inherited from root project
 
 dependencies {

--- a/pushpin-security-jwt/build.gradle.kts
+++ b/pushpin-security-jwt/build.gradle.kts
@@ -1,3 +1,6 @@
+plugins {
+    id("com.vanniktech.maven.publish")
+}
 // All configuration is inherited from root project
 
 dependencies {

--- a/pushpin-security-ratelimit/build.gradle.kts
+++ b/pushpin-security-ratelimit/build.gradle.kts
@@ -1,3 +1,6 @@
+plugins {
+    id("com.vanniktech.maven.publish")
+}
 // All configuration is inherited from root project
 
 dependencies {

--- a/pushpin-security-remote/build.gradle.kts
+++ b/pushpin-security-remote/build.gradle.kts
@@ -1,3 +1,6 @@
+plugins {
+    id("com.vanniktech.maven.publish")
+}
 // All configuration is inherited from root project
 
 dependencies {

--- a/pushpin-security-starter/build.gradle.kts
+++ b/pushpin-security-starter/build.gradle.kts
@@ -1,3 +1,6 @@
+plugins {
+    id("com.vanniktech.maven.publish")
+}
 // All configuration is inherited from root project
 
 dependencies {

--- a/pushpin-testcontainers/build.gradle.kts
+++ b/pushpin-testcontainers/build.gradle.kts
@@ -1,3 +1,6 @@
+plugins {
+    id("com.vanniktech.maven.publish")
+}
 // All configuration is inherited from root project
 
 description = "Testcontainers support for Pushpin server"

--- a/pushpin-transport-core/build.gradle.kts
+++ b/pushpin-transport-core/build.gradle.kts
@@ -1,3 +1,6 @@
+plugins {
+    id("com.vanniktech.maven.publish")
+}
 // All configuration is inherited from root project
 
 dependencies {

--- a/pushpin-transport-http/build.gradle.kts
+++ b/pushpin-transport-http/build.gradle.kts
@@ -1,3 +1,6 @@
+plugins {
+    id("com.vanniktech.maven.publish")
+}
 // All configuration is inherited from root project
 
 dependencies {

--- a/pushpin-transport-zmq/build.gradle.kts
+++ b/pushpin-transport-zmq/build.gradle.kts
@@ -1,3 +1,6 @@
+plugins {
+    id("com.vanniktech.maven.publish")
+}
 // All configuration is inherited from root project
 
 dependencies {


### PR DESCRIPTION
This pull request adds the `com.vanniktech.maven.publish` plugin to all module-specific `build.gradle.kts` files in the project. This change standardizes the publishing process across all modules by leveraging the Maven Publish plugin.

### Plugin Addition for Maven Publishing:

* Added the `com.vanniktech.maven.publish` plugin to the following module-specific `build.gradle.kts` files:
  - `pushpin-api`
  - `pushpin-client`
  - `pushpin-discovery-aws`
  - `pushpin-discovery-kubernetes`
  - `pushpin-discovery`
  - `pushpin-metrics-core`
  - `pushpin-security-audit`
  - `pushpin-security-core`
  - `pushpin-security-encryption`
  - `pushpin-security-hmac`
  - `pushpin-security-jwt`
  - `pushpin-security-ratelimit`
  - `pushpin-security-remote`
  - `pushpin-security-starter`
  - `pushpin-testcontainers`
  - `pushpin-transport-core`
  - `pushpin-transport-http`
  - `pushpin-transport-zmq`