### PR TITLE
feat: simplify CI configuration by updating publish command to publish all publications

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,4 +186,4 @@ jobs:
         ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.GPG_KEY_ID }}
         ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PASSPHRASE }}
         ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_PRIVATE_KEY }}
-      run: ./gradlew publishAllPublicationsToMavenCentralRepository
+      run: ./gradlew publish


### PR DESCRIPTION
This pull request includes a small change to the GitHub Actions workflow file `.github/workflows/ci.yml`. The change simplifies the Gradle command used during the CI process by replacing `publishAllPublicationsToMavenCentralRepository` with the more general `publish` command.